### PR TITLE
Help: add vertical scrolling with mouse and keyboard

### DIFF
--- a/O21.Game/Game.fs
+++ b/O21.Game/Game.fs
@@ -21,7 +21,7 @@ type Config = {
     
 type Game<'World, 'GameData, 'Input> = {
     LoadGameData: unit -> 'GameData
-    Init: unit -> 'World
+    Init: 'GameData -> 'World
     HandleInput: int -> 'Input
     Update: 'Input -> Time -> 'World -> 'World
     PostUpdate: 'GameData -> 'World -> 'World
@@ -50,7 +50,7 @@ type GameState<'World, 'GameData, 'Input>(config: Config, game: Game<_, _, _>) =
                                   float32 width, float32 height)
         gameRect <- Rectangle(0.0f, 0.0f, float32 config.GameWidth, -float32 config.GameHeight)
         
-        world <- game.Init()
+        world <- game.Init gameData
 
     member _.LoadContent() =
         gameData <- game.LoadGameData()
@@ -76,8 +76,8 @@ module GameState =
         SetTargetFPS(60)
 
         let loop = new GameState<'World, 'Content, 'Input>(config, game)
-        loop.Initialize()
         loop.LoadContent()
+        loop.Initialize()
 
         while not (WindowShouldClose()) do
             let time = { 

--- a/O21.Game/Input.fs
+++ b/O21.Game/Input.fs
@@ -9,6 +9,7 @@ type Input = {
     Pressed: Key list
     MouseCoords: Vector2
     MouseButtonPressed: bool
+    MouseWheelMove: float32
 }
 
 module Input =
@@ -31,4 +32,5 @@ module Input =
 
         { Pressed = keys
           MouseCoords = Vector2(mouse.X / float32 scale, mouse.Y / float32 scale)
-          MouseButtonPressed = Raylib.IsMouseButtonPressed(MouseButton.MOUSE_BUTTON_LEFT) }
+          MouseButtonPressed = Raylib.IsMouseButtonPressed(MouseButton.MOUSE_BUTTON_LEFT)
+          MouseWheelMove = Raylib.GetMouseWheelMove() }

--- a/O21.Game/O21Game.fs
+++ b/O21.Game/O21Game.fs
@@ -6,9 +6,9 @@ open O21.Game.Scenes
 open O21.Game.U95
 
 module O21Game =
-    let init (dataDirectory: string) = {
+    let private init (dataDirectory: string) gameData = {
         SoundVolume = 0.1f
-        Scene = MainMenuScene.Init(GameContent.Load())
+        Scene = MainMenuScene.Init(GameContent.Load(), gameData)
         // TODO[#47]: Async commands
         CurrentLevel = (Level.Load dataDirectory 1 2).Result
         SoundsToStartPlaying = Set.empty
@@ -33,7 +33,7 @@ module O21Game =
         LoadGameData = fun () ->
             // TODO[#38]: Preloader, combine with downloader
             (U95Data.Load dataDirectory).Result
-        Init = (fun () -> init dataDirectory)
+        Init = init dataDirectory
         HandleInput = Input.handle
         Update = update
         PostUpdate = postUpdate

--- a/O21.Game/Scenes/HelpScene.fs
+++ b/O21.Game/Scenes/HelpScene.fs
@@ -23,7 +23,7 @@ type HelpScene =
             BackButton = Button.Create content.UiFontRegular "Back" <| Vector2(200f, 00f)
             Previous = previous
             OffsetY = 0f
-            TotalHeight = HelpScene.GetFragmentsHeight content.UiFont data.Help
+            TotalHeight = HelpScene.GetFragmentsHeight content data.Help
         }
         member private this.textColor = BLACK
 
@@ -43,14 +43,22 @@ type HelpScene =
                 else
                     0f
 
-        static member GetFragmentsHeight (font: Font) fragments =
+        static member private MeasureFragment content style (text: string) =
+            let font =
+                match style with
+                    | Style.Bold -> content.UiFontBold
+                    | _ -> content.UiFontRegular
+
+            font, MeasureTextEx(font, text, float32 font.baseSize, 0.0f)
+
+        static member private GetFragmentsHeight content fragments =
             let mutable fragmentsHeight = 0f
             let mutable currentLineHeight = 0f
 
             for fragment in fragments do
                 match fragment with
-                    | DocumentFragment.Text(_, text) ->
-                        let size = MeasureTextEx(font, text, float32 font.baseSize, 0.0f)
+                    | DocumentFragment.Text(style, text) ->
+                        let _, size = HelpScene.MeasureFragment content style text
                         currentLineHeight <- max currentLineHeight size.Y
                     | DocumentFragment.NewParagraph ->
                         fragmentsHeight <- fragmentsHeight + currentLineHeight
@@ -70,12 +78,7 @@ type HelpScene =
                 for fragment in data.Help do
                     match fragment with
                         | DocumentFragment.Text(style, text) ->
-                            let font =
-                                match style with
-                                    | Style.Bold -> this.Content.UiFontBold
-                                    | _ -> this.Content.UiFontRegular
-
-                            let size = MeasureTextEx(font, text, float32 font.baseSize, 0.0f)
+                            let font, size = HelpScene.MeasureFragment this.Content style text
                             DrawTextEx(font, text, Vector2(x, y), float32 font.baseSize, 0.0f, this.textColor)
                             x <- x + size.X
                             currentLineHeight <- max currentLineHeight size.Y

--- a/O21.Game/Scenes/MainMenuScene.fs
+++ b/O21.Game/Scenes/MainMenuScene.fs
@@ -2,14 +2,17 @@ namespace O21.Game.Scenes
 
 open System.Numerics
 open O21.Game
+open O21.Game.U95
 
 type MainMenuScene = {
+    Data: U95Data
     Content: GameContent
     PlayButton: Button
     HelpButton: Button
 }
     with
-        static member Init(content: GameContent): MainMenuScene = {
+        static member Init(content: GameContent, data: U95Data): MainMenuScene = {
+            Data = data
             Content = content
             PlayButton = Button.Create content.UiFontRegular "Play" <| Vector2(0f, 00f)
             HelpButton = Button.Create content.UiFontRegular "Help" <| Vector2(0f, 20f)
@@ -30,7 +33,7 @@ type MainMenuScene = {
                     }
                 let scene: IGameScene =
                     if scene.PlayButton.State = ButtonState.Clicked then PlayScene()
-                    elif scene.HelpButton.State = ButtonState.Clicked then HelpScene.Init (this.Content, this)
+                    elif scene.HelpButton.State = ButtonState.Clicked then HelpScene.Init (this.Content, this.Data, this)
                     else scene
                 { world with
                     Scene = scene


### PR DESCRIPTION
Closes #59 

@ForNeVeR
> Currently, there's a small fragment of the help page that doesn't fit on the main screen.

Which fragment were you talking about? I achieved overflow of help page content only by manually changing the game's height in the `Program.fs`

Also, maybe there is a better way to get the total fragments height without making an additional pass?


Demos with different window height:

https://user-images.githubusercontent.com/38229504/232258500-7434e920-fa78-47a0-9127-16a1e8d647ad.mp4

https://user-images.githubusercontent.com/38229504/232258515-9524cb5a-7c31-4a8a-a248-9e17fc68732d.mp4


