### PR TITLE
Micro optimization.

### DIFF
--- a/O21.Game/GeometryUtils.fs
+++ b/O21.Game/GeometryUtils.fs
@@ -3,6 +3,12 @@ module O21.Game.GeometryUtils
 open System
 open System.Numerics
 
+let private halfPi = float32 <| Math.PI/2.0
+
+let private IntersectHorizontalLine (angle: float32) : float32 = (0.5f / tan angle) + 0.5f 
+
+let private IntersectWithVerticalLine (angle: float32) : float32 = (0.5f * tan angle) + 0.5f
+
 let GenerateSquareSector: double -> Vector2[] = function
     | x when x <= 0.0 -> Array.empty
     | x when x >= 1.0 -> [|
@@ -14,15 +20,13 @@ let GenerateSquareSector: double -> Vector2[] = function
         |]
     | p ->
         let angle = float32 <| 2.0 * Math.PI * p
-        let x = sin angle / 2f * sqrt 2f + 0.5f
-        let y = -cos angle / 2f * sqrt 2f + 0.5f
         [|
             Vector2(0.5f, 0.5f)
-            if p <= 0.125 then Vector2(x, 0f) else
-                if p <= 0.375 then Vector2(1f, y) else
-                    if p <= 0.625 then Vector2(x, 1f) else
-                        if p < 0.875 then Vector2(0f, y) else
-                            Vector2(x, 0f)
+            if p <= 0.125 then Vector2(IntersectHorizontalLine (halfPi - angle), 0f) else
+                if p <= 0.375 then Vector2(1f, IntersectWithVerticalLine (angle - halfPi)) else
+                    if p <= 0.625 then Vector2(IntersectHorizontalLine (angle - halfPi), 1f) else
+                        if p < 0.875 then Vector2(0f, IntersectWithVerticalLine (halfPi - angle)) else
+                            Vector2(IntersectHorizontalLine (halfPi - angle), 0f)
                             Vector2(0f, 0f)
                         Vector2(0f, 1f)
                     Vector2(1f, 1f)


### PR DESCRIPTION
![explaining math](https://github.com/ForNeVeR/O21/assets/8425417/f9c57177-b034-4c63-a882-967143e4ee0a)
For 0 ≤ angle ≤ π/2
α = angle
β = π/2 - α
tan(β) = (0.5 - y₀)/(x₀ - 0.5)
To find intersection with top border of rectangle assume y₀ = 0
x₀ = 0.5/tan(β) + 0.5

I believe this way is more accurate than circle intersection.