### PR TITLE
Health and restarting game implemented

### DIFF
--- a/O21.Game/Engine/Entities.fs
+++ b/O21.Game/Engine/Entities.fs
@@ -66,7 +66,7 @@ and OxygenStorage = {
         let timer = this.Timer.Update(timeDelta)
         if timer.HasExpired then
             let newAmount =
-                if this.Amount >= 0 then
+                if not this.IsEmpty then
                     this.Amount - timer.ExpirationCount
                 else GameRules.MaxOxygenUnits
             {                

--- a/O21.Game/Engine/GameEngine.fs
+++ b/O21.Game/Engine/GameEngine.fs
@@ -82,8 +82,12 @@ type GameEngine = {
         match effect with
         | PlayerEffect.Update player -> { engine with Player = player }, Array.empty
         | PlayerEffect.Die ->
-            { engine with GameEngine.Player.Velocity = Vector.Zero }, [| PlaySound SoundType.LifeLost |]
-            // TODO[#26]: Lose a life: keep lives in the player object and add updated player to PlayerEffect.Die
+            { engine with
+                Player = { engine.Player with
+                            Velocity = Vector.Zero
+                            Lives = Math.Max(engine.Player.Lives - 1, 0)
+                            Oxygen = OxygenStorage.Default }
+            }, [| PlaySound SoundType.LifeLost |]
             // TODO[#26]: Player sprite should be replaced with explosion for a while
             // TODO[#26]: Investigate how shot cooldown and direction should behave on resurrect: are they reset or not?
             // TODO[#27]: Investigate if enemy collision should stop the player from moving

--- a/O21.Game/Engine/GameRules.fs
+++ b/O21.Game/Engine/GameRules.fs
@@ -39,7 +39,7 @@ let ClampVelocity(Vector(x, y)): Vector =
    )
    
 [<Literal>]
-let MaxOxygenUnits = 5
+let MaxOxygenUnits = 100
 
 [<Literal>]
 let OxygenUnitPeriod = 22

--- a/O21.Game/Engine/GameRules.fs
+++ b/O21.Game/Engine/GameRules.fs
@@ -17,6 +17,12 @@ let GameScreenHeight = 400
 let ShotCooldownTicks = 15
 
 [<Literal>]
+let MaxPlayerLives = 9
+
+[<Literal>]
+let InitialPlayerLives = 5
+
+[<Literal>]
 let LevelWidth = GameScreenWidth
 
 [<Literal>]
@@ -33,7 +39,7 @@ let ClampVelocity(Vector(x, y)): Vector =
    )
    
 [<Literal>]
-let MaxOxygenUnits = 100
+let MaxOxygenUnits = 5
 
 [<Literal>]
 let OxygenUnitPeriod = 22

--- a/O21.Game/HUD.fs
+++ b/O21.Game/HUD.fs
@@ -28,7 +28,7 @@ type HUD =
                 Lives = 5
                 Abilities = Array.init 5 (fun _ -> false )
                 Pause = false 
-                Controls =  Controls.Init()
+                Controls = Controls.Init()
             }
             
         member private this.renderBonusLine(textures: HUDSprites)  =
@@ -61,6 +61,7 @@ type HUD =
             
         member this.SyncWithGame(gameEngine:GameEngine) =
             { this with
+                Lives = gameEngine.Player.Lives
                 Oxy = gameEngine.Player.OxygenAmount
                 Pause = not gameEngine.IsActive
             }

--- a/O21.Game/Input.fs
+++ b/O21.Game/Input.fs
@@ -8,7 +8,7 @@ open System.Numerics
 open Raylib_CsLo
 open type Raylib_CsLo.Raylib
 
-type Key = Left | Right | Up | Down | Fire | Pause
+type Key = Left | Right | Up | Down | Fire | Pause | Restart
 
 type Input = {
     Pressed: Set<Key>
@@ -26,6 +26,7 @@ module Input =
                 KeyboardKey.KEY_LEFT, Left
                 KeyboardKey.KEY_RIGHT, Right
                 KeyboardKey.KEY_SPACE, Fire
+                KeyboardKey.KEY_F2, Restart
                 KeyboardKey.KEY_F3, Pause
             ]
 

--- a/O21.Game/Scenes/PlayScene.fs
+++ b/O21.Game/Scenes/PlayScene.fs
@@ -60,6 +60,9 @@ module private InputProcessor =
                 game <- game'
                 effects <- Array.append effects effects'
             game, effects
+            
+    let RestartKeyPressed (input: Input) = Set.contains Key.Restart input.Pressed
+        
 
 type PlayScene = {
     HUD: HUD
@@ -104,12 +107,14 @@ type PlayScene = {
             let sounds =
                 state.SoundsToStartPlaying +
                 (allEffects |> Seq.map(fun (PlaySound s) -> s) |> Set.ofSeq)
-            let navigationEvent =
-                if this.HUD.Lives < 0 then
-                    // TODO[#32]: Should be handled by the game engine
+            let state, navigationEvent =
+                if this.HUD.Lives <= 0 then
+                    { state with Game = fst <| state.Game.ApplyCommand(PlayerCommand.Suspend) },
                     Some (NavigateTo Scene.GameOver)
+                else if InputProcessor.RestartKeyPressed input then
+                    state, Some (NavigateTo Scene.Play)
                 else
-                    None
+                    state, None
 
             { state with SoundsToStartPlaying = sounds }, navigationEvent
  

--- a/O21.Game/U95/Sprites.fs
+++ b/O21.Game/U95/Sprites.fs
@@ -20,6 +20,7 @@ type PlayerSprites =
     {
         Left: Texture[]
         Right: Texture[]
+        Explosion: Texture[]
     }
 
     static member Load(lifetime: Lifetime) (images: Dib[]): PlayerSprites =
@@ -27,7 +28,8 @@ type PlayerSprites =
             CreateTransparentSprite lifetime images[i] images[i + 24]
         let right = seq { 6; yield! [| 17..23 |] } |> Seq.map loadImageByIndex |> Seq.toArray
         let left = seq { yield! [| 7..13 |]; 24 } |> Seq.map loadImageByIndex |> Seq.toArray
-        { Left = left; Right = right }
+        let explosion = seq { yield! [| 16..18 |] } |> Seq.map loadImageByIndex |> Seq.toArray
+        { Left = left; Right = right; Explosion = explosion }
 
 type Sprites = {
     Bricks: Map<int, Texture>

--- a/O21.Tests/GameEngineTests.fs
+++ b/O21.Tests/GameEngineTests.fs
@@ -158,6 +158,19 @@ module OxygenSystem =
         let gameEngine = frameUpN timeZero period gameEngine
         Assert.Equal(expected, gameEngine.Player.OxygenAmount)
         
+    [<Fact>]
+    let ``Player dies when oxygen amount is empty``(): unit =
+        let level = { LevelMap = [| [| Empty |] |] }
+        let player = Player.Default
+        
+        let player = { player with Player.Oxygen.Amount = 1 }
+        let player' = player.Update(level, 0);
+        Assert.True(match player' with | PlayerEffect.Update _ -> true | _ -> false)
+        
+        let player = { player with Player.Oxygen.Amount = -1 }
+        let player' = player.Update(level, 0)
+        Assert.True(match player' with | PlayerEffect.Die -> true | _ -> false)
+        
 module ParticleSystem =
     
     [<Fact>]


### PR DESCRIPTION
This pr contains:
1. Heath system (live decreases if player dies) Issue #26
2. Player dies when oxygen storage is empty Issue #31 
3. Shows game over scene when the player is out of lives Issue #32
4. Game restarts when F2 key is pressed Issue #85 
5. Test for oxygen system (lives decreasing)
6. Import explosion textures

- Closes #31.
- Closes #32.
- Closes #85.
